### PR TITLE
Fix rotating with styled-components v4

### DIFF
--- a/src/Rect/index.js
+++ b/src/Rect/index.js
@@ -138,7 +138,7 @@ export default class Rect extends PureComponent {
 
     return (
       <StyledRect
-        innerRef={this.setElementRef}
+        ref={this.setElementRef}
         onMouseDown={this.startDrag}
         className="rect single-resizer"
         style={style}


### PR DESCRIPTION
**styled-components@v4** [changed the way refs work](https://www.styled-components.com/docs/faqs#what-do-i-need-to-do-to-migrate-to-v4) which broke rotations completely. This commit adds support for using  **styled-components@v4**.