### PR TITLE
Drag should start only when MAIN mouse button is clicked

### DIFF
--- a/src/Rect/index.js
+++ b/src/Rect/index.js
@@ -35,6 +35,7 @@ export default class Rect extends PureComponent {
 
   // Drag
   startDrag = (e) => {
+    if (e.button !== 0) return
     let { clientX: startX, clientY: startY } = e
     this.props.onDragStart && this.props.onDragStart()
     this._isMouseDown = true


### PR DESCRIPTION
Currently clicking on the secondary button opens contextual menu and starts drag simultaneously which is undesired.